### PR TITLE
Add Dockerfile for FastAPI intent service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source code
+COPY . .
+
+# Expose the FastAPI port
+EXPOSE 8000
+
+# Default command to run the API service
+CMD ["uvicorn", "intent_api:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile to run the intent_api FastAPI service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6b58394708332a297558bc5bb1ba9