### PR TITLE
Add Docker Hub publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/python-intent-recognition
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest
+

--- a/README.md
+++ b/README.md
@@ -212,3 +212,22 @@ This implementation includes extensive comments and documentation to help unders
 - Model evaluation and validation techniques for Chinese text
 - GPU acceleration and optimization strategies
 - Chinese text processing and tokenization methods
+## Docker Image & GitHub Actions
+
+This project provides a Dockerfile and a GitHub Actions workflow for publishing a Docker image to Docker Hub.
+
+### Build locally
+
+```bash
+docker build -t your-username/python-intent-recognition .
+docker run -p 8000:8000 your-username/python-intent-recognition
+```
+
+### Configure GitHub Actions
+
+1. Create repository secrets named `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` with your Docker Hub credentials.
+2. The workflow in `.github/workflows/docker-publish.yml` runs on pushes to `main`, tags beginning with `v`, or manual dispatch.
+3. The image is published as `docker.io/<username>/python-intent-recognition:latest`.
+
+You can trigger the workflow from the Actions tab once the secrets are configured.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and push Docker image to Docker Hub
- document Docker workflow setup and local build instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker build -t test-intent-recognition .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c76337a0248332b19006b5d00e6be1