### PR TITLE
Support merging generated dataset splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ chinese_intent_recognition/
    ```bash
    python -m dataset.dataset_creator
    ```
+   Running the generator multiple times will append the newly created splits to any existing `data/train.csv` or `data/test.csv` files while removing duplicate `(text, label)` pairs. To regenerate a clean dataset from scratch, delete the `data/` directory (or the individual split files) before re-running the command.
 
 3. Train the Chinese RoBERTa model:
    ```bash


### PR DESCRIPTION
## Summary
- detect existing dataset files and merge new splits while dropping duplicate samples
- update label mapping persistence to keep prior label ids and include the union of intents in the merged data
- document the new merge behaviour and how to reset the dataset when regenerating

## Testing
- python -m dataset.dataset_creator

------
https://chatgpt.com/codex/tasks/task_e_68d8eb2662008332a2ebffe1c2564c52